### PR TITLE
enabled shared posts to be liked

### DIFF
--- a/src/app/Http/Controllers/UserPostController.php
+++ b/src/app/Http/Controllers/UserPostController.php
@@ -76,7 +76,7 @@ class UserPostController extends Controller
      */
     public function likePost(Request $request):RedirectResponse
     {
-        $this->userPostService->likePost($request->post);
+        $this->userPostService->likePost(['type' => $request->type, 'id' => $request->id]);
         return redirect('/posts-page');
     }
 
@@ -85,7 +85,7 @@ class UserPostController extends Controller
      */
     public function unlikePost(Request $request):RedirectResponse
     {
-        $this->userPostService->unlikePost($request->post);
+        $this->userPostService->unlikePost(['type' => $request->type, 'id' => $request->id]);
         return redirect('/posts-page');
     }
 }

--- a/src/app/Models/PostLike.php
+++ b/src/app/Models/PostLike.php
@@ -20,6 +20,7 @@ class PostLike extends Model
     protected $fillable = [
         'user_id',
         'post_id',
+        'post_share_id'
     ];
 
     /**
@@ -30,6 +31,7 @@ class PostLike extends Model
     protected $casts = [
         'user_id' => 'integer',
         'post_id' => 'integer',
+        'post_share_id' => 'integer',
     ];
 
     /**

--- a/src/app/Models/PostShare.php
+++ b/src/app/Models/PostShare.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class PostShare extends Model
@@ -31,5 +32,10 @@ class PostShare extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function postLike(): HasMany 
+    {
+        return $this->hasMany(PostLike::class, 'post_share_id');
     }
 }

--- a/src/database/migrations/2024_05_23_011359_add_post_share_id_to_post_likes_table.php
+++ b/src/database/migrations/2024_05_23_011359_add_post_share_id_to_post_likes_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPostShareIdToPostLikesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('post_likes', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_share_id')->nullable()->after('post_id');
+            $table->foreign('post_share_id')->references('id')->on('post_shares')->onDelete('cascade');
+            $table->unique(['user_id', 'post_share_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('post_likes', function (Blueprint $table) {
+            $table->dropForeign(['post_share_id']);
+            $table->dropColumn('post_share_id');
+            $table->dropUnique(['user_id', 'post_id']);
+            $table->dropUnique(['user_id', 'post_share_id']);
+        });
+    }
+}

--- a/src/database/migrations/2024_05_23_021643_make_post_id_nullable_in_post_likes_table.php
+++ b/src/database/migrations/2024_05_23_021643_make_post_id_nullable_in_post_likes_table.php
@@ -26,8 +26,6 @@ class MakePostIdNullableInPostLikesTable extends Migration
     public function down()
     {
         Schema::table('post_likes', function (Blueprint $table) {
-            // If you need to revert the change, you can make the column non-nullable again.
-            // This will drop any existing NULL values in the column.
             $table->unsignedBigInteger('post_id')->change();
         });
     }

--- a/src/database/migrations/2024_05_23_021643_make_post_id_nullable_in_post_likes_table.php
+++ b/src/database/migrations/2024_05_23_021643_make_post_id_nullable_in_post_likes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MakePostIdNullableInPostLikesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('post_likes', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('post_likes', function (Blueprint $table) {
+            // If you need to revert the change, you can make the column non-nullable again.
+            // This will drop any existing NULL values in the column.
+            $table->unsignedBigInteger('post_id')->change();
+        });
+    }
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -23,10 +23,10 @@ Route::middleware([AuthenticateWithErrorView::class])->group(function () {
     Route::get('/update-profile', [ProfileController::class, 'showUpdateProfile']);
     Route::post('/update-profile', [ProfileController::class, 'update']);
     Route::post('/create-post', [UserPostController::class, 'create']);
-    Route::post('/like-post/{post}', [UserPostController::class, 'likePost']);
+    Route::post('/like-post', [UserPostController::class, 'likePost']);
     Route::post('/share-post', [PostShareController::class, 'create']);
     Route::put('/edit-post', [UserPostController::class, 'edit']);
-    Route::delete('/unlike-post/{post}', [UserPostController::class, 'unlikePost']);
+    Route::delete('/unlike-post', [UserPostController::class, 'unlikePost']);
     Route::delete('/delete-post/{post}', [UserPostController::class, 'delete']);
     Route::post('/add-comment', [PostCommentController::class, 'create']);
     Route::delete('/delete-comment', [PostCommentController::class, 'delete']);


### PR DESCRIPTION
**OVERVIEW**

Currently, only the original posts can be liked/unliked. To enable the users to also like/unlike posts,

WE:

1. Created a new migration to add a new column in post_likes table that would determine if a like belongs to an original post or a shared post. Also added unique constraints for user_id and post_share_id.

2. Created a new migration that makes post_id column nullable.

3. I added post_share_id as fillable in the PostLike.php model .

4. Added relationship methods in PostShare.php model.

5. Modified the like and unlike function in service to accept both original.
