### PR TITLE
Improvement/shared post and profile page

### DIFF
--- a/src/app/Http/Controllers/RelationshipController.php
+++ b/src/app/Http/Controllers/RelationshipController.php
@@ -26,8 +26,8 @@ class RelationshipController extends Controller
     /**
      * Calls service to unfollow a user.
      */
-    public function unfollow(Request $request): void
+    public function unfollow(Request $request): RedirectResponse
     {
-        $this->relationshipService->unfollow($request->user_to_unfollow);
+        return redirect($this->relationshipService->unfollow($request->userToUnfollowId));
     }
 }

--- a/src/app/Services/RelationshipService.php
+++ b/src/app/Services/RelationshipService.php
@@ -27,10 +27,12 @@ class RelationshipService
     /**
      * Changes the status of relationship to false
      */
-    public function unfollow(int $userToUnfollowId): void
+    public function unfollow(int $userToUnfollowId): string
     {
         Relationship::where('follower_id', auth()->user()->id)
             ->where('following_id', $userToUnfollowId)
             ->update(['status' => false]);
+        
+            return '/posts-page';
     }
 }

--- a/src/app/Services/UserPostService.php
+++ b/src/app/Services/UserPostService.php
@@ -92,8 +92,9 @@ class UserPostService
      * Retrieves and combines user posts with media and shares, then sorts by date.
      * */
     public function getAllPostsAndMediaAndShares(): Collection
-    {
-        $userPosts = UserPost::all();
+    {   
+        $followedUserIds = auth()->user()->followedUsers()->where('status', 1)->pluck('following_id')->toArray();
+        $userPosts = UserPost::whereIn('user_id', $followedUserIds)->get();
         $postsMedia = PostMedia::all();
         $postsAndMedia = [];
 

--- a/src/app/Services/UserPostService.php
+++ b/src/app/Services/UserPostService.php
@@ -94,6 +94,7 @@ class UserPostService
     public function getAllPostsAndMediaAndShares(): Collection
     {   
         $followedUserIds = auth()->user()->followedUsers()->where('status', 1)->pluck('following_id')->toArray();
+        $followedUserIds[] = auth()->user()->id;
         $userPosts = UserPost::whereIn('user_id', $followedUserIds)->get();
         $postsMedia = PostMedia::all();
         $postsAndMedia = [];

--- a/src/database/migrations/2024_06_07_025455_update_post_shares_table_remove_cascade_on_delete.php
+++ b/src/database/migrations/2024_06_07_025455_update_post_shares_table_remove_cascade_on_delete.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdatePostSharesTableRemoveCascadeOnDelete extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('post_shares', function (Blueprint $table) {
+            // Drop the existing foreign keys
+            $table->dropForeign(['post_id']);
+            $table->dropForeign(['user_id']);
+            
+            // Recreate the foreign keys without cascade on delete
+            $table->foreign('post_id')->references('id')->on('user_posts');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('post_shares', function (Blueprint $table) {
+            // Drop the foreign keys without cascade on delete
+            $table->dropForeign(['post_id']);
+            $table->dropForeign(['user_id']);
+            
+            // Recreate the original foreign keys with cascade on delete
+            $table->foreign('post_id')->references('id')->on('user_posts')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+}

--- a/src/database/migrations/2024_06_07_025455_update_post_shares_table_remove_cascade_on_delete.php
+++ b/src/database/migrations/2024_06_07_025455_update_post_shares_table_remove_cascade_on_delete.php
@@ -8,17 +8,13 @@ class UpdatePostSharesTableRemoveCascadeOnDelete extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::table('post_shares', function (Blueprint $table) {
-            // Drop the existing foreign keys
             $table->dropForeign(['post_id']);
             $table->dropForeign(['user_id']);
             
-            // Recreate the foreign keys without cascade on delete
             $table->foreign('post_id')->references('id')->on('user_posts');
             $table->foreign('user_id')->references('id')->on('users');
         });
@@ -26,17 +22,13 @@ class UpdatePostSharesTableRemoveCascadeOnDelete extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::table('post_shares', function (Blueprint $table) {
-            // Drop the foreign keys without cascade on delete
             $table->dropForeign(['post_id']);
             $table->dropForeign(['user_id']);
             
-            // Recreate the original foreign keys with cascade on delete
             $table->foreign('post_id')->references('id')->on('user_posts')->onDelete('cascade');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });

--- a/src/database/migrations/2024_06_07_031004_remove_post_id_foreign_key_from_post_shares.php
+++ b/src/database/migrations/2024_06_07_031004_remove_post_id_foreign_key_from_post_shares.php
@@ -8,26 +8,20 @@ class RemovePostIdForeignKeyFromPostShares extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::table('post_shares', function (Blueprint $table) {
-            // Drop the foreign key constraint on post_id
             $table->dropForeign(['post_id']);
         });
     }
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::table('post_shares', function (Blueprint $table) {
-            // Recreate the foreign key constraint on post_id
             $table->foreign('post_id')->references('id')->on('user_posts');
         });
     }

--- a/src/database/migrations/2024_06_07_031004_remove_post_id_foreign_key_from_post_shares.php
+++ b/src/database/migrations/2024_06_07_031004_remove_post_id_foreign_key_from_post_shares.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemovePostIdForeignKeyFromPostShares extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('post_shares', function (Blueprint $table) {
+            // Drop the foreign key constraint on post_id
+            $table->dropForeign(['post_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('post_shares', function (Blueprint $table) {
+            // Recreate the foreign key constraint on post_id
+            $table->foreign('post_id')->references('id')->on('user_posts');
+        });
+    }
+}

--- a/src/resources/views/components/buttons/interaction.blade.php
+++ b/src/resources/views/components/buttons/interaction.blade.php
@@ -36,9 +36,11 @@
     <button onclick="showComment('{{ $type }}-{{ $postId }}')" class="col-span-1 hover:bg-mydark hover:text-mycream font-semibold justify-center items-center p-2 transition-all rounded">
         Comment
     </button>
-    <button onclick="showUserPost({{ $postsMediumOrShare['post']->id }})" class="col-span-1 hover:bg-mydark hover:text-mycream font-semibold justify-center items-center p-2 transition-all rounded">
-        Share
-    </button>
+    @if (!$postsMediumOrShare instanceof App\Models\PostShare)
+        <button onclick="showUserPost({{ $postsMediumOrShare['post']->id }})" class="col-span-1 hover:bg-mydark hover:text-mycream font-semibold justify-center items-center p-2 transition-all rounded">
+            Share
+        </button>
+    @endif
 </div>
 
 <div id="{{ $type }}-{{ $postId }}" class="fixed left-0 top-0 bg-mydark bg-opacity-50 w-full h-full justify-center items-center opacity-0 hidden transition-opacity duration-500 flex">

--- a/src/resources/views/components/counter/following.blade.php
+++ b/src/resources/views/components/counter/following.blade.php
@@ -1,4 +1,4 @@
 <div class="font-semibold text-center">
-    <p class="text-mywhite cursor-pointer hover:text-mygray">{{ $user->followedUsers->count() }}</p>
+    <p class="text-mywhite cursor-pointer hover:text-mygray">{{ $user->followedUsers->where('status', 1)->count() }}</p>
     <span class="text-mycream cursor-pointer hover:text-mygray">Following</span>
 </div>

--- a/src/resources/views/components/counter/post.blade.php
+++ b/src/resources/views/components/counter/post.blade.php
@@ -1,4 +1,4 @@
 <div class="font-semibold text-center">
-    <p class="text-mywhite cursor-pointer hover:text-mygray">{{$user->userPost->count() }}</p>
+    <p class="text-mywhite cursor-pointer hover:text-mygray">{{$user->userPost->count() + $user->postShare->count()}}</p>
     <span class="text-mycream cursor-pointer hover:text-mygray">Posts</span>
 </div>

--- a/src/resources/views/components/modals/share-post.blade.php
+++ b/src/resources/views/components/modals/share-post.blade.php
@@ -1,3 +1,4 @@
+@if(!$postsMediumOrShare instanceof App\Models\PostShare)
 <div id="sharepost-{{ $postsMediumOrShare['post']->id }}" class="fixed left-0 top-0 bg-mydark bg-opacity-50 w-full h-full justify-center items-center opacity-0 hidden transition-opacity duration-500 z-9999">
     <div onclick="event.stopImmediatePropagation()" class="bg-mycream rounded-2xl shadow-md w-11/12 max-w-lg max-h-[calc(100vh-50px)] overflow-y-auto">
         <form action="/share-post" method="POST">
@@ -19,3 +20,4 @@
         </div>
     </div>
 </div>
+@endif

--- a/src/resources/views/components/sections/follow-suggestions.blade.php
+++ b/src/resources/views/components/sections/follow-suggestions.blade.php
@@ -3,6 +3,7 @@
     $unfollowedUsers = 
         App\Models\User::whereKeyNot($authUserId)
         ->whereNotIn('id', auth()->user()->followedUsers->pluck('following_id'))
+        ->inRandomOrder()
         ->take(3)
         ->get();
 @endphp

--- a/src/resources/views/components/sections/post.blade.php
+++ b/src/resources/views/components/sections/post.blade.php
@@ -7,7 +7,6 @@
 
     <div class="w-auto m-3 py-2">
         @if ($postsMediumOrShare instanceof App\Models\PostShare)
-
             <div class="w-auto m-3">
                 <div class="flex flex-row p-2 mx-1 w-auto">
                     <x-profile-icon.small :user="$postsMediumOrShare->user"/>
@@ -38,40 +37,46 @@
 
 
             <div class="w-auto m-3 py-2 hover:shadow-lg rounded-lg border-2 border-opacity-20 border-mygray">
-                <div class="flex flex-row p-2 mx-3 w-auto border-mygray">
-                    <x-profile-icon.small :user="$postsMediumOrShare->user"/>
-                    <div class="flex flex-col mb-2 ml-4 mt-1">
-                        <div class="text-mydark text-sm font-semibold cursor-pointer">
-                        <form action="{{ route('profile.show.profile.page') }}" method="GET">
-                            <input name="userId" value="{{$postsMediumOrShare->user->id}}" hidden>
-                            <button class="font-semibold text-mydark cursor-pointer">
-                                    {{ $postsMediumOrShare->post->user->username }}
-                            </button>
-                        </form>
-                        </div>
-                        @if ($showTimerAndEdit)
-                            <div class="flex w-full mt-1">
-                                <div class="text-mydark flex font-light text-xs gap-2">
-                                    {{ $postsMediumOrShare['post']->created_at->diffForHumans() }}
-                                </div>
-                                <x-svgs.edit-icon />
+                @if (!empty($postsMediumOrShare->post))
+                    <div class="flex flex-row p-2 mx-3 w-auto border-mygray">
+                        <x-profile-icon.small :user="$postsMediumOrShare->post->user"/>
+                        <div class="flex flex-col mb-2 ml-4 mt-1">
+                            <div class="text-mydark text-sm font-semibold cursor-pointer">
+                            <form action="{{ route('profile.show.profile.page') }}" method="GET">
+                                <input name="userId" value="{{$postsMediumOrShare->post->user->id}}" hidden>
+                                <button class="font-semibold text-mydark cursor-pointer">
+                                        {{ $postsMediumOrShare->post->user->username }}
+                                </button>
+                            </form>
                             </div>
-                        @endif
+                            @if ($showTimerAndEdit)
+                                <div class="flex w-full mt-1">
+                                    <div class="text-mydark flex font-light text-xs gap-2">
+                                        @if (!empty($postsMediumOrShare->post))
+                                            {{ $postsMediumOrShare->post->created_at->diffForHumans() }}
+                                            <x-svgs.edit-icon />
+                                            @endif
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
                     </div>
-                </div>
-
-                <div class="text-mydark font-medium text-sm m-3 hover:drop-shadow-md">
-                    @if (!empty($postsMediumOrShare['post']) && !empty($postsMediumOrShare['post']->content))
-                        {{ $postsMediumOrShare['post']->content }}
-                    @endif
-                </div>
-
-                <div class="w-auto h-auto flex justify-center items-center m-3 pb-4">
+                
+                    <div class="text-mydark font-medium text-sm m-3 hover:drop-shadow-md">
+                            {{ $postsMediumOrShare->post->content }}
+                    </div>
+                    
                     @if (!empty($postsMediumOrShare->post->postMedia))
+                        <div class="w-auto h-auto flex justify-center items-center m-3 pb-4"></div>
                         <img class="flex justify-center items-center mx-3 rounded-md w-96 h-96 object-contain"
                             src="{{ asset($postsMediumOrShare->post->postMedia->image) }}" alt="post image">
-                    @endif
-                </div>
+                            </div>
+                     @endif
+                @else
+                    <div class="text-mydark font-medium text-sm m-3 hover:drop-shadow-md">
+                        Content is not available.
+                    </div>
+                @endif
             </div>
         @else
             <div class="flex flex-row p-2 mx-3 w-auto">

--- a/src/resources/views/profile/index.blade.php
+++ b/src/resources/views/profile/index.blade.php
@@ -24,7 +24,7 @@
                         <x-counter.following :user="$user"/>
                     </div>
                     <div class="flex justify-center items-center">
-                    @if(!auth()->user()->followedUsers->contains($user))
+                    @if(auth()->user()->followedUsers->contains($user))
                         <form action="{{ route('relationship.follow') }}" method="POST">
                             @csrf
                             <input name="userToFollowId" value ="{{ $user->id }}" hidden>
@@ -32,6 +32,17 @@
                                 class="flex items-center justify-center text-center text-xs font-semibold bg-mycream text-mydark hover:bg-mygray hover:text-mycream p-3 rounded-full transition-all">
                                 <x-svgs.follow-icon />
                                 Follow
+                            </button>
+                        </form>
+                    @else
+                        <form action="{{ route('relationship.unfollow') }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <input name="userToUnfollowId" value ="{{ $user->id }}" hidden>
+                            <button
+                                class="flex items-center justify-center text-center text-xs font-semibold bg-mycream text-mydark hover:bg-mygray hover:text-mycream p-3 rounded-full transition-all">
+                                <x-svgs.follow-icon />
+                                Unfollow
                             </button>
                         </form>
                     @endif 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -44,6 +44,7 @@ Route::middleware([AuthenticateWithErrorView::class])->group(function () {
     Route::delete('/delete-comment', [PostCommentController::class, 'delete']);
     Route::put('/edit-comment', [PostCommentController::class, 'update']);
     Route::put('/edit-comment', [PostCommentController::class, 'update']);
+    Route::delete('/unfollow-user', [RelationshipController::class, 'unfollow'])->name('relationship.unfollow');
     Route::post('/follow-user', [RelationshipController::class, 'follow'])->name('relationship.follow');
     Route::get('/show-profile-page', [ProfileController::class, 'showProfilePage'])->name('profile.show.profile.page');
 });


### PR DESCRIPTION
**OVERVIEW**
1. Display "content unavailable when referencing a deleted post"
2. Display count of original + shared posts of user
3. Fixed bug where user's profile photo or username in shared post doesnt redirect correctly to the user's profile page.
4. Disabled sharing of already shared posts.
5. Enabled seeing only the posts of followed users.
6. Added 2 migrations for "Display 'content unavailable when referencing a deleted post'" to be possible.